### PR TITLE
Fix panic on 'wasm32-unknown-unknown' target.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ include = ["/src/", "/Cargo.toml", "/CHANGELOG.md", "/LICENSE.md", "/README.md"]
 features = ["failure"]
 
 [dependencies]
-dm = { version = "0.99.2", package = "derive_more" }
+derive_more = "0.99.2"
 [dependencies.failure]
     version = "0.1.6"
     optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,7 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
+use derive_more as dm;
 #[cfg(feature = "failure")]
 use failure::Fail;
 

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -5,6 +5,8 @@ use std::{
     ops::{Deref, DerefMut},
 };
 
+use derive_more as dm;
+
 /// Captured frame of [`Trace`].
 #[derive(Clone, Copy, Debug, dm::Display)]
 #[display(fmt = "{}\n  at {}:{}", module, file, line)]


### PR DESCRIPTION
Compiler panic:

Compiler panic occurs when trying to build tracerr on `wasm32-unknown-unknown` target (`cargo build --target=wasm32-unknown-unknown`)

```
thread 'rustc' panicked at 'src/librustc_resolve/macros.rs:715: inconsistent resolution for a macro', src/librustc/util/bug.rs:37:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

error: internal compiler error: unexpected panic

note: the compiler unexpectedly panicked. this is a bug.

note: we would appreciate a bug report: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md#bug-reports

note: rustc 1.39.0 (4560ea788 2019-11-04) running on x86_64-unknown-linux-gnu

note: compiler flags: -C debuginfo=2 -C incremental --crate-type lib

note: some of the compiler flags provided by cargo are hidden

error: could not compile `tracerr`.

To learn more, run the command again with --verbose.
```

It is already reported https://github.com/rust-lang/rust/issues/64450.