### PR TITLE
Add a way to construct Traced from err and Trace

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -4,7 +4,7 @@
 
 max_width = 80
 format_strings = false
-merge_imports = true
+imports_granularity = "Crate"
 
 format_code_in_doc_comments = true
 format_macro_matchers = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
+## [0.2.0] · 2021-??-?? ~TBD
+[0.2.0]: /../../tree/v0.2.0
+
+[Diff](/../../compare/v0.1.2...v0.2.0)
+
+### Added
+
+- Implement `From<(E, Trace)>` for `Traced<E>` ([#4](/../../pull/4)).
+
+### BC Breaks
+
+- Change `Traced::from_parts()` arguments to `(err: E, trace: Trace)` ([#4](/../../pull/4)).
+
+
+
+
 ## [0.1.2] · 2020-11-03
 [0.1.2]: /../../tree/v0.1.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,15 @@ All user visible changes to this project will be documented in this file. This p
 
 [Diff](/../../compare/v0.1.2...v0.2.0)
 
-### Added
-
-- Implement `From<(E, Trace)>` for `Traced<E>` ([#4](/../../pull/4)).
-
 ### BC Breaks
 
-- Change `Traced::from_parts()` arguments to `(err: E, trace: Trace)` ([#4](/../../pull/4)).
+- Change `Traced::from_parts()` arguments to `(err: E, trace: Trace)` ([#4]).
+
+### Added
+
+- `From<(E, Trace)>` implementation for `Traced<E>` ([#4]).
+
+[#4]: /../../pull/4
 
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,8 +112,8 @@ impl<E> Traced<E> {
 
     /// Composes given error and the captured [`Trace`] into a [`Traced`] error.
     #[inline]
-    pub fn from_parts(err: E, f: Frame) -> Self {
-        err.wrap_traced(f)
+    pub fn from_parts(err: E, trace: Trace) -> Self {
+        Traced { err, trace }
     }
 
     /// References to the captured [`Trace`].
@@ -129,7 +129,14 @@ impl<E> Traced<E> {
 impl<E> From<(E, Frame)> for Traced<E> {
     #[inline]
     fn from((err, f): (E, Frame)) -> Self {
-        Self::from_parts(err, f)
+        err.wrap_traced(f)
+    }
+}
+
+impl<E> From<(E, Trace)> for Traced<E> {
+    #[inline]
+    fn from((err, trace): (E, Trace)) -> Self {
+        Traced::from_parts(err, trace)
     }
 }
 


### PR DESCRIPTION
Change `Traced::from_parts()` from `fn from_parts(err: E, f: Frame) -> Self` to `fn from_parts(err: E, trace: Trace) -> Self`.

Add `impl<E> From<(E, Trace)> for Traced<E>`.